### PR TITLE
Fixed typos on about-company and about-team pages

### DIFF
--- a/_harp/about/_company.md
+++ b/_harp/about/_company.md
@@ -2,4 +2,4 @@
 
 *Founders & Coders C.I.C.* runs what is probably the most challenging course in software development in the UK. We take students with little or no knowledge of programming and bring them up to a level where they are capable of finding employment, working freelance or starting their own project. We aim for 100% of our graduates to be earning a living in software development.
 
-Our intention is to provide the best possible training in web development - for free. We manage this through the support of our mentors, the tech communtiy and our graduates, who often join our faculty to help to teach future cohorts.
+Our intention is to provide the best possible training in web development - for free. We manage this through the support of our mentors, the tech community and our graduates, who often join our faculty to help to teach future cohorts.

--- a/_harp/about/_team.md
+++ b/_harp/about/_team.md
@@ -33,7 +33,7 @@
 	<a href="https://uk.linkedin.com/pub/campbell-morgan/46/b60/805" target="_blank" class="team-image campbell"></a>
 
 	**Campbell Morgan**	
-	Campbell is a web-developer with a background in design and 3D animation. Campbell is the founder of <a href="http://www.sitechef.co.uk/" target="_blank">SiteChef</a>. He is also the founder of <a href="http://www.folissimo.com/#/" target="_blank">Folissimo</a>.
+	Campbell is a web developer with a background in design and 3D animation. Campbell is the founder of <a href="http://www.sitechef.co.uk/" target="_blank">SiteChef</a>. He is also the founder of <a href="http://www.folissimo.com/#/" target="_blank">Folissimo</a>.
 
 	<a href="https://github.com/alanshaw/" target="_blank" class="team-image alan"></a>
 


### PR DESCRIPTION
'Community' was spelled incorrectly on the company page.

Changed 'web-developer' to 'web developer' in Campbell's description to be consistent across the site.