### PR TITLE
Adds link to Ladies Who Code page

### DIFF
--- a/_harp/about/_team.md
+++ b/_harp/about/_team.md
@@ -9,7 +9,7 @@
 	<a href="https://www.linkedin.com/in/iteles" target="_blank" class="team-image ines"></a>
 
 	**Ines Teles**
-	Ines is a director of *Founders & Coders C.I.C.*, project manager, developer and organiser of *Ladies who Code*. She previously spent several years as a consultant at *Accenture*.
+	Ines is a director of *Founders & Coders C.I.C.*, project manager, developer and organiser of [*Ladies who Code*](www.meetup.com/Ladies-Who-Code-UK/). She previously spent several years as a consultant at *Accenture*.
 
 	<a href="https://www.linkedin.com/in/nelsonic" target="_blank" class="team-image nelson"></a>
 


### PR DESCRIPTION
_Ladies Who Code_ is mentioned on the team page and it feels like intuitively this should be a link (at least I automatically tried to press on it).
This PR adds the link for better UX in case people want to find out more.

Thanks