### PR TITLE
Hero image text: changes "January course" to "summer course"

### DIFF
--- a/_harp/academy/index.ejs
+++ b/_harp/academy/index.ejs
@@ -1,7 +1,7 @@
 <div class="academy-landing">
 	<h1><span class="display">Collaborative Environment +</span> Cutting-edge Curriculum.</h1>
 	<p><span class="display">Our JavaScript-driven curriculum immerses you in the latest web technologies including Node.js, React and hapi.</span></p>
-	<p>Applications are now open for our January course</p>
+	<p>Applications are now open for our summer course.</p>
 	<a onclick="fac.nav_scroll('/academy/', 'apply')" class="margin"><button class="button-three">APPLY</button></a>
 </div>
 <div class="section-copy">


### PR DESCRIPTION
Noticed that the text on the [hero image](http://www.foundersandcoders.com/academy/) was still making reference to January.  I've changed to match @rub1e's [pull request](https://github.com/foundersandcoders/oursite/pull/210) 

Went for "Applications are now open for our **summer** course" - thought it would sound smoother than "Applications are now open for our May/June course". 