### PR TITLE
Related #104

### DIFF
--- a/_harp/_partials/navbar.ejs
+++ b/_harp/_partials/navbar.ejs
@@ -1,4 +1,7 @@
 <nav id="navbar">
+	<div class="nav-logo">
+		<img src="../assets/fac-logo.png"/>
+	</div>
 	<div class="desktop-only">
 		<ul class="animate-header">
 

--- a/_harp/about/_press.md
+++ b/_harp/about/_press.md
@@ -1,15 +1,3 @@
-## Video archive
-
-<div class="vid">
-    <iframe width="720" height="408" src="https://www.youtube.com/embed/jnW7YzZ9GwQ" frameborder="0" allowfullscreen></iframe>
-</div>
-Ines Teles at the CAST launch event, June 30th, 2016
-
-<div class="vid">
-	<iframe src="https://player.vimeo.com/video/115169756" width="720px" height="408px" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</div>
-Founders & Coders at Camden Collective, Autumn 2014
-
 ## Press
 
 - [Get with the program: the coders offering training for free](https://www.theguardian.com/technology/2015/jul/26/founders-coders-coding-free-training-london) (The Guardian)

--- a/_harp/about/_video.md
+++ b/_harp/about/_video.md
@@ -1,0 +1,11 @@
+## Video archive
+
+<div class="vid">
+    <iframe width="720" height="408" src="https://www.youtube.com/embed/jnW7YzZ9GwQ" frameborder="0" allowfullscreen></iframe>
+</div>
+Ines Teles at the CAST launch event, June 30th, 2016.
+
+<div class="vid">
+	<iframe src="https://player.vimeo.com/video/115169756" width="720px" height="408px" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+</div>
+Founders & Coders at Camden Collective, Autumn 2014

--- a/_harp/css/features/_navbar.scss
+++ b/_harp/css/features/_navbar.scss
@@ -19,9 +19,9 @@ nav {
 			height: 100%;
 		}
 		position: absolute;
-		left: -1%;
+		left: 0%;
 		padding: 2%;
-		height: 20vh;
+		height: inherit;
 	}
 	p {
 		float: right;
@@ -211,10 +211,6 @@ nav {
 
 @media (max-width: $mobile) {
 	nav {
-		.nav-logo {
-			height: 10vh;
-			left: 0;
-		}
 		height: 10vh;
 		p {
 			line-height: 10vh;

--- a/_harp/css/features/_navbar.scss
+++ b/_harp/css/features/_navbar.scss
@@ -20,7 +20,7 @@ nav {
 		}
 		position: absolute;
 		left: 0%;
-		padding: 2%;
+		padding: 2.5vh;
 		height: inherit;
 	}
 	p {
@@ -211,6 +211,9 @@ nav {
 
 @media (max-width: $mobile) {
 	nav {
+		.nav-logo {
+			padding: 3px;
+		}
 		height: 10vh;
 		p {
 			line-height: 10vh;

--- a/_harp/css/features/_navbar.scss
+++ b/_harp/css/features/_navbar.scss
@@ -14,6 +14,15 @@ nav {
 	h4 {
 		cursor: pointer;
 	}
+	.nav-logo {
+		img {
+			height: 100%;
+		}
+		position: absolute;
+		left: -1%;
+		padding: 2%;
+		height: 20vh;
+	}
 	p {
 		float: right;
 		line-height: 20vh;
@@ -202,6 +211,10 @@ nav {
 
 @media (max-width: $mobile) {
 	nav {
+		.nav-logo {
+			height: 10vh;
+			left: 0;
+		}
 		height: 10vh;
 		p {
 			line-height: 10vh;


### PR DESCRIPTION
I have taken the existing fac-logo.png file in the Assets directory to add the logo.
To position it top left of the navbar (without pushing aside the navigation links) it is;
- positioned absolutely.
- given corresponding nav height rules (20vh for deskopt/tablet, 10vh for mobile). 

A small amount of padding is used in relation to the container height so that it scales, and a small amount of left positioning is used on desktop view to ensure the logo never overlaps with the navigation links