### PR TITLE
Added link back to pre-programme

### DIFF
--- a/_harp/apply/_apply.md
+++ b/_harp/apply/_apply.md
@@ -3,6 +3,8 @@
   Applications for our February course in London are now closed.
 
   Applications for our February course in Nazareth close on December 31.
+  
+  NOTE: if you want help with meeting the prerequisites, [SIGN UP NOW for our Nazareth pre-programme](https://goo.gl/forms/X8pjSrshOG7UrW0U2) running in January.
 
 <h2 align='center'> HOW DO I APPLY FOR THE PROGRAMME?<h2>
 


### PR DESCRIPTION
We mistakenly removed the link to the pre-programme. That needs to be added back, but renamed to *"pre-programme"*. Fixes #376 